### PR TITLE
tons of user interface/experience improvements

### DIFF
--- a/widgets/TrojanGoSettingsWidget.hpp
+++ b/widgets/TrojanGoSettingsWidget.hpp
@@ -3,6 +3,7 @@
 #include "interface/QvGUIPluginInterface.hpp"
 #include "ui_TrojanGoSettingsWidget.h"
 
+#include <QTimer>
 #include <optional>
 
 /**
@@ -44,13 +45,33 @@ class TrojanGoSettingsWidget
 
   protected:
     void changeEvent(QEvent *e) override;
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
 
   private slots:
+    void debounceUnfreeze();
     void on_selectKernelBtn_clicked();
-    void on_kernelPathTxt_textEdited(const QString &arg1);
+    void on_testKernelBtn_clicked();
 
   private:
     QJsonObject settings;
+    QTimer debounceTimer;
+
+  private:
+    // platform-dependent options.
+#if defined(Q_OS_MAC)
+    const inline static char *platformDefaultKernelDir = "/usr/local/bin";
+    const inline static char *platformKernelPathFilter = "Trojan-Go Core(trojan-go*);;All Files(*)";
+#elif defined(Q_OS_UNIX)
+    const inline static char *platformDefaultKernelDir = "/usr/bin";
+    const inline static char *platformKernelPathFilter = "Trojan-Go Core(trojan-go*);;All Files(*)";
+#elif defined(Q_OS_WIN)
+    const inline static char *platformDefaultKernelDir = "";
+    const inline static char *platformKernelPathFilter = "Trojan-Go Core(trojan-go.exe);;All Files(*)";
+#else
+    const inline static char *platformDefaultKernelDir = "";
+    const inline static char *platformKernelPathFilter = "";
+#endif
 
   private:
     /**
@@ -59,4 +80,12 @@ class TrojanGoSettingsWidget
      * @return if the kernel path check passes, and if not, the detailed error message.
      */
     std::tuple<KernelPathCheckerResult, std::optional<QString>> preliminaryKernelPathChecker(const QString &pathToKernel);
+
+    /**
+     * @brief The UI routine to handle kernel path check.
+     *        To be reused by multiple part of this program.
+     * @param pathToCheck the path to be checked.
+     * @return if the backend should accept the user input.
+     */
+    bool handleKernelPathCheck(const QString &pathToCheck);
 };

--- a/widgets/TrojanGoSettingsWidget.ui
+++ b/widgets/TrojanGoSettingsWidget.ui
@@ -6,34 +6,85 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>651</width>
-    <height>300</height>
+    <width>534</width>
+    <height>332</height>
    </rect>
+  </property>
+  <property name="acceptDrops">
+   <bool>true</bool>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QFormLayout" name="formLayout">
    <item row="0" column="0">
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="kernelLabel">
      <property name="text">
-      <string>Trojan-Go Kernel Path</string>
+      <string>Kernel</string>
      </property>
     </widget>
    </item>
    <item row="0" column="1">
+    <widget class="QLineEdit" name="kernelPathTxt">
+     <property name="acceptDrops">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string notr="true"/>
+     </property>
+     <property name="dragEnabled">
+      <bool>false</bool>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+     <property name="placeholderText">
+      <string>(N/A)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLineEdit" name="kernelPathTxt"/>
-     </item>
      <item>
       <widget class="QPushButton" name="selectKernelBtn">
        <property name="text">
-        <string>Select Kernel</string>
+        <string>&amp;Browse...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="testKernelBtn">
+       <property name="text">
+        <string>&amp;Test Run...</string>
        </property>
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QLabel" name="notesLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>&lt;h3&gt;Tips:&lt;/h3&gt;
+QvPlugin-Trojan-Go requires Trojan-Go Core to function well.
+&lt;br&gt;
+Please locate Trojan-Go kernel using &lt;b&gt;Browse...&lt;/b&gt; button, or by &lt;b&gt;dragging&lt;/b&gt; the kernel file in. Optionally, do a &lt;b&gt;Test Run&lt;/b&gt; before leaving.</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
- added explicit instructions for configuring Trojan-Go core file
- supported drag-drop kernel file detection
- supported test-run of Trojan-Go core
- suppressed the direct editing of core path. if wanted, this can be done by manually editing JSON.

![图片](https://user-images.githubusercontent.com/7822648/95507695-5b118380-09e4-11eb-99e4-b183faa40ce2.png)
